### PR TITLE
Add getting of templates from RHMAP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ _testmain.go
 
 # Binaries
 rhm
+
+.DS_Store

--- a/commands/get/get.go
+++ b/commands/get/get.go
@@ -15,6 +15,7 @@ func NewGetCmd(in io.Reader, out io.Writer, store storage.Storer) cli.Command {
 		Subcommands: []cli.Command{
 			NewProjectsCmd(in, out, store),
 			NewProjectCmd(in, out, store),
+			NewTemplatesCmd(in, out, store),
 		},
 	}
 }

--- a/commands/get/templates.go
+++ b/commands/get/templates.go
@@ -1,0 +1,153 @@
+package get
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/feedhenry/rhm/commands"
+	"github.com/feedhenry/rhm/storage"
+	"github.com/urfave/cli"
+)
+
+// NewGetTemplateCmd forms the basis of getting templates of various types
+func (tc *templatesCmd) Templates() cli.Command {
+	return cli.Command{
+		Name:   "templates",
+		Usage:  "templates",
+		Action: tc.templatesAction,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:        "type",
+				Destination: &tc.templateType,
+				Usage:       "The type of the templates (e.g. projects, apps etc.) ",
+				Value:       "projects",
+			},
+			cli.StringFlag{
+				Name:        "id",
+				Destination: &tc.templateID,
+				Usage:       "The ID of the template to retrieve, only returns for an exact match",
+			},
+			cli.StringFlag{
+				Name:        "name",
+				Destination: &tc.templateName,
+				Usage:       "The name of the template to retrieve, will return any template which contains the provided string",
+			},
+		},
+	}
+}
+
+// templatesCmd constructs the required writer in order to send the response to the right place.
+type templatesCmd struct {
+	out          io.Writer
+	in           io.Reader
+	getter       func(*http.Request) (*http.Response, error)
+	store        storage.Storer
+	templateType string
+	templateID   string
+	templateName string
+}
+
+// ListTemplates gets a list of templates of the supplied templateType (e.g. projects)
+func (tc *templatesCmd) templatesAction(ctx *cli.Context) error {
+	var url = "%s/box/api/templates/%s"
+
+	userData, err := tc.store.ReadUserData()
+	if err != nil {
+		return cli.NewExitError("could not read userData "+err.Error(), 1)
+	}
+
+	fullURL := fmt.Sprintf(url, userData.Host, tc.templateType)
+
+	newrequest, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return cli.NewExitError("could not create new request object "+err.Error(), 1)
+	}
+
+	// create a cookie
+	cookie := http.Cookie{Name: "feedhenry", Value: userData.Auth}
+	newrequest.AddCookie(&cookie)
+	//do request
+
+	resp, err := tc.getter(newrequest)
+	if err != nil {
+		return cli.NewExitError("could not create new request object "+err.Error(), 1)
+	}
+	defer resp.Body.Close()
+
+	ret, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return cli.NewExitError("failed to read response body "+err.Error(), 1)
+	}
+
+	//check if not authed)
+	if err := handleTemplatesResponseStatus(resp.StatusCode); err != nil {
+		tc.out.Write(ret)
+		return err
+	}
+
+	var resJSON []*commands.Template
+	if err := json.Unmarshal(ret, &resJSON); err != nil {
+		return cli.NewExitError("failed to decode response :"+err.Error(), 1)
+	}
+
+	if tc.templateID != "" {
+		resJSON, err = filterTemplates(resJSON, tc.templateID, func(template *commands.Template, templateID string) bool {
+			return template.ID == templateID
+		})
+	}
+	if err != nil {
+		return cli.NewExitError("Failed to find template with ID :"+err.Error(), 1)
+	}
+
+	if tc.templateName != "" {
+		resJSON, err = filterTemplates(resJSON, tc.templateName, func(template *commands.Template, templateName string) bool {
+			return strings.Contains(strings.ToLower(template.Name), strings.ToLower(templateName))
+		})
+	}
+	if err != nil {
+		return cli.NewExitError("Failed to find template with Title :"+err.Error(), 1)
+	}
+
+	t := template.New("project templates list template")
+	t, _ = t.Parse("{{range . }} | ID | {{.ID}} | Name | {{.Name}} | Category | {{.Category}} \n\n  {{end}}")
+	if err := t.Execute(tc.out, resJSON); err != nil {
+		return cli.NewExitError("failed to execute template "+err.Error(), 1)
+	}
+
+	return nil
+}
+
+// handleTemplatesResponseStatus checks whether the API request returned an ok response
+func handleTemplatesResponseStatus(status int) error {
+	if status == http.StatusOK {
+		return nil
+	}
+	return cli.NewExitError(fmt.Sprintf("\n response %d \n", status), 1)
+}
+
+// filterTemplates returns a list of templates depending on a supplied comparison function
+func filterTemplates(templates []*commands.Template, templateName string, filterFunction func(*commands.Template, string) bool) ([]*commands.Template, error) {
+	var match []*commands.Template
+	for _, v := range templates {
+		if filterFunction(v, templateName) {
+			match = append(match, v)
+		}
+	}
+	if len(match) == 0 {
+		return nil, cli.NewExitError("No matches found", 1)
+	}
+
+	return match, nil
+}
+
+//NewTemplatesCmd configures the templatesCmd for use with the client
+func NewTemplatesCmd(in io.Reader, out io.Writer, store storage.Storer) cli.Command {
+	var client http.Client
+	tc := &templatesCmd{out: out, in: in, getter: client.Do, store: store}
+	return tc.Templates()
+}

--- a/commands/get/templates_test.go
+++ b/commands/get/templates_test.go
@@ -1,0 +1,77 @@
+package get
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/feedhenry/rhm/storage"
+	"github.com/feedhenry/rhm/test/mock"
+)
+
+func TestTemplatesAction(t *testing.T) {
+	var (
+		mockStore = mock.UserDataStore(storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"))
+		in        bytes.Buffer
+		out       bytes.Buffer
+	)
+	response := `[{"name": "example-template", "id": "scqswfv56m7fktyijkfw6tkd", "category": "this is a category"}]`
+	tCmd := &templatesCmd{
+		in:           &in,
+		out:          &out,
+		store:        mockStore,
+		templateType: "projects",
+		getter:       mock.CreateRequest(t, 200, "testing.feedhenry.me/box/api/templates/projects", response),
+	}
+	if err := tCmd.templatesAction(nil); err != nil {
+		t.Fatal("failed to exectute templates cmd" + err.Error())
+	}
+	content := string(out.Bytes())
+	if !strings.Contains(content, "example-template") {
+		t.Fatal("expected the template title to be present")
+	}
+	if !strings.Contains(content, "scqswfv56m7fktyijkfw6tkd") {
+		t.Fatal("expected the template guid to be present")
+	}
+	if !strings.Contains(content, "this is a category") {
+		t.Fatal("expected the template description to be present")
+	}
+}
+
+func TestTemplatesAction401Error(t *testing.T) {
+	var (
+		mockStore = mock.UserDataStore(storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"))
+		in        bytes.Buffer
+		out       bytes.Buffer
+	)
+	response := `{"status":"error"}`
+	tCmd := &templatesCmd{
+		in:           &in,
+		out:          &out,
+		store:        mockStore,
+		templateType: "projects",
+		getter:       mock.CreateRequest(t, 401, "testing.feedhenry.me/box/api/templates/projects", response),
+	}
+	if err := tCmd.templatesAction(nil); err == nil {
+		t.Fatal("expected an error executing command")
+	}
+}
+
+func TestTemplatesAction500Error(t *testing.T) {
+	var (
+		mockStore = mock.UserDataStore(storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"))
+		in        bytes.Buffer
+		out       bytes.Buffer
+	)
+	response := `{"status":"error"}`
+	tCmd := &templatesCmd{
+		in:           &in,
+		out:          &out,
+		store:        mockStore,
+		templateType: "projects",
+		getter:       mock.CreateRequest(t, 500, "testing.feedhenry.me/box/api/templates/projects", response),
+	}
+	if err := tCmd.templatesAction(nil); err == nil {
+		t.Fatal("expected an error executing command ")
+	}
+}

--- a/commands/types.go
+++ b/commands/types.go
@@ -32,3 +32,10 @@ type App struct {
 	ScmURL    string `json:"scmUrl"`
 	Title     string `json:"title"`
 }
+
+// Template defines the project template response object
+type Template struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Category string `json:"category"`
+}


### PR DESCRIPTION
There is still a lot to do here, I started working on it only getting projects, but it makes sense to instead allow all types of templates to be gotten through this PR just by generalising everything a bit so I've started on that now. 

Just wanted to keep this here so I can get some feedback. It's used like this:

```
rhm get templates projects
```

which is similar to the fhc style, however maybe something like

```
rhm get templates --type=project
```
would make more sense. Then the directory structure could be flattened again.

At the moment it is also only list, not getting an individual one.

@maleck13 would you mind taking a look?

***Edit:*** It also needs tests too.
