### PR TITLE
Issue 28

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ _testmain.go
 rhm
 
 .DS_Store
+
+.idea
+rhm.iml

--- a/README.md
+++ b/README.md
@@ -38,14 +38,17 @@ New commands should go under commands.
 Ensure you are running go 1.7 or later.
 
 Install glide first [it's on GitHub](https://github.com/Masterminds/glide)
+```
+go get github.com/Masterminds/glide
+```
 
 ```
     go get github.com/feedhenry/rhm
     cd $GOPATH/src/github.com/feedhenry/rhm
     glide install
-    go build .
+    go install
     # test it works
-    ./rhm 
+    rhm 
     # run the tests 
     go test ./... 
 ```

--- a/commands/get/apps.go
+++ b/commands/get/apps.go
@@ -9,6 +9,12 @@ import (
 type appsCmd struct{}
 
 func (ac appsCmd) appsAction(ctx *cli.Context) error {
-	fmt.Println("here")
+	switch ctx.GlobalString("o") {
+	case "json":
+		fmt.Println("{msg: \"here\"}")
+	default:
+		fmt.Println("here")
+	}
+
 	return nil
 }

--- a/commands/get/environments.go
+++ b/commands/get/environments.go
@@ -68,7 +68,7 @@ func (ec *environmentsCmd) environmentsAction(ctx *cli.Context) error {
 	defer res.Body.Close()
 
 	var dataStructure []*commands.Environment
-	return ui.NewOutPutter(ctx.GlobalString("o"), res.Body, ec.out, environmentTemplate, &dataStructure).Output()
+	return ui.NewPrinter(ctx.GlobalString("o"), res.Body, ec.out, environmentTemplate, &dataStructure).Print()
 
 }
 

--- a/commands/get/environments.go
+++ b/commands/get/environments.go
@@ -21,19 +21,10 @@ type environmentsCmd struct {
 	store  storage.Storer
 }
 
-var environmentListTemplate = `
-{{range . }} 
-Id      |  {{ .ID}} 
-Label   |  {{ .Label}} 
-Enabled |  {{ .Enabled}}
-Target  |
-
-  -- Id     | {{ .Target.ID}}
-  -- Label  | {{ .Target.Label}}
-  -- Env    | {{ .Target.Env}}
-
-
-{{end}}        
+var environmentTemplate = `
+| {{PadRight 14 " " "Id"}}| {{PadRight 14 " " "Label"}}| {{PadRight 14 " " "Enabled"}}| {{PadRight 14 " " "Target.id"}}| {{PadRight 14 " " "Target.Label"}}| {{PadRight 14 " " "Target.Env"}}|
+|-{{PadRight 14 "-" ""}}+-{{PadRight 14 "-" ""}}+-{{PadRight 14 "-" ""}}+-{{PadRight 14 "-" ""}}+-{{PadRight 14 "-" ""}}+-{{PadRight 14 "-" ""}}|{{range . }}
+| {{PadRight 14 " " .ID}}| {{PadRight 14 " " .Label}}| {{if .Enabled}}{{PadRight 14 " " "Yes"}}{{else}}{{PadRight 14 " " "No"}}{{end}}| {{PadRight 14 " " .Target.ID}}| {{PadRight 14 " " .Target.Label}}| {{PadRight 14 " " .Target.Env}}|{{end}}
 `
 
 //Environment Defines our cli command including its flags and usage then returns the command to allow a user to do specific operations on environments
@@ -76,16 +67,9 @@ func (ec *environmentsCmd) environmentsAction(ctx *cli.Context) error {
 	}
 	defer res.Body.Close()
 
-	op := ui.NewOutPutter(res.Body, ec.out)
-	//handle Output
-	switch ctx.GlobalString("o") {
-	case "json":
-		return op.OutputJSON()
-	default:
-		var environmentsModel []*commands.Environment
-		return op.OutputTemplate(environmentListTemplate, &environmentsModel)
-	}
-	return nil
+	var dataStructure []*commands.Environment
+	return ui.NewOutPutter(ctx.GlobalString("o"), res.Body, ec.out, environmentTemplate, &dataStructure).Output()
+
 }
 
 // handleEnvironmentsResponseStatus checks whether the API request returned an ok response

--- a/commands/get/environments_test.go
+++ b/commands/get/environments_test.go
@@ -7,9 +7,15 @@ import (
 
 	"github.com/feedhenry/rhm/storage"
 	"github.com/feedhenry/rhm/test/mock"
+	"github.com/urfave/cli"
+	"flag"
 )
 
+var outPutType string
+
 func TestEnvironmentsAction(t *testing.T) {
+	cxt := cli.NewContext(cli.NewApp(), flag.NewFlagSet("o", 0), nil)
+	cxt.GlobalSet("o", "json")
 	var (
 		mockStore = mock.UserDataStore(storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"))
 		in        bytes.Buffer
@@ -22,7 +28,7 @@ func TestEnvironmentsAction(t *testing.T) {
 		store:  mockStore,
 		getter: mock.CreateRequest(t, 200, "testing.feedhenry.me/api/v2/environments/all", response),
 	}
-	if err := eCmd.environmentsAction(nil); err != nil {
+	if err := eCmd.environmentsAction(cxt); err != nil {
 		t.Fatal("failed to exectute environments cmd" + err.Error())
 	}
 	content := string(out.Bytes())
@@ -41,6 +47,8 @@ func TestEnvironmentsAction(t *testing.T) {
 }
 
 func TestEnvironmentsAction401Error(t *testing.T) {
+	cxt := cli.NewContext(cli.NewApp(), flag.NewFlagSet("o", 0), nil)
+	cxt.GlobalSet("o", "json")
 	var (
 		mockStore = mock.UserDataStore(storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"))
 		in        bytes.Buffer
@@ -53,12 +61,14 @@ func TestEnvironmentsAction401Error(t *testing.T) {
 		store:  mockStore,
 		getter: mock.CreateRequest(t, 401, "testing.feedhenry.me/api/v2/environments/all", response),
 	}
-	if err := eCmd.environmentsAction(nil); err == nil {
+	if err := eCmd.environmentsAction(cxt); err == nil {
 		t.Fatal("expected an error executing command")
 	}
 }
 
 func TestProjectsTestEnvironmentsAction401Error(t *testing.T) {
+	cxt := cli.NewContext(cli.NewApp(), flag.NewFlagSet("o", 0), nil)
+	cxt.GlobalSet("o", "json")
 	var (
 		mockStore = mock.UserDataStore(storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"))
 		in        bytes.Buffer
@@ -71,7 +81,7 @@ func TestProjectsTestEnvironmentsAction401Error(t *testing.T) {
 		store:  mockStore,
 		getter: mock.CreateRequest(t, 500, "testing.feedhenry.me/api/v2/environments/all", response),
 	}
-	if err := eCmd.environmentsAction(nil); err == nil {
+	if err := eCmd.environmentsAction(cxt); err == nil {
 		t.Fatal("expected an error executing command ")
 	}
 }

--- a/commands/get/environments_test.go
+++ b/commands/get/environments_test.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	"flag"
+
 	"github.com/feedhenry/rhm/storage"
 	"github.com/feedhenry/rhm/test/mock"
 	"github.com/urfave/cli"
-	"flag"
 )
 
 var outPutType string

--- a/commands/get/project.go
+++ b/commands/get/project.go
@@ -13,18 +13,10 @@ import (
 )
 
 var projectTemplate = `
-| Title |  {{.Title}}
-| Email |  {{.AuthorEmail}}
-| Guid  |  {{.GUID}}
-| Type  |  {{.Type}}
-        {{if .Apps}}
-        | Apps |
-                {{range .Apps }}
-               | Title | {{.Title}}
-               | Guid  | {{.GUID}}
-
-                {{end}}
-        {{end}}
+==== Project Data ====
+| {{PadRight 14 " " "Title"}}| {{PadRight 30 " " "Email"}}| {{PadRight 28 " " "GUID"}}| {{PadRight 14 " " "Type"}}|
++-{{PadRight 14 "-" ""}}+-{{PadRight 30 "-" ""}}+-{{PadRight 28 "-" ""}}+-{{PadRight 14 "-" ""}}+
+| {{PadRight 14 " " .Title}}| {{PadRight 30 " " .AuthorEmail}}| {{PadRight 28 " " .GUID}}| {{PadRight 14 " " .Type}}|
 `
 
 type projectCmd struct {
@@ -83,19 +75,9 @@ func (pc *projectCmd) projectAction(ctx *cli.Context) error {
 		pc.out.Write(data)
 		return cli.NewExitError(fmt.Sprintf("\n unexpected response %d \n", res.StatusCode), 1)
 	}
-	projectModel := &commands.Project{}
 
-	op := ui.NewOutPutter(res.Body, pc.out)
-	//handle Output
-	switch ctx.GlobalString("o") {
-	case "json":
-		return op.OutputJSON()
-	default:
-		return op.OutputTemplate(projectTemplate, projectModel)
-	}
-
-	return nil
-
+	var dataStructure commands.Project
+	return ui.NewOutPutter(ctx.GlobalString("o"), res.Body, pc.out, projectTemplate, &dataStructure).Output()
 }
 
 // NewProjectCmd configures a new project command

--- a/commands/get/project.go
+++ b/commands/get/project.go
@@ -77,7 +77,7 @@ func (pc *projectCmd) projectAction(ctx *cli.Context) error {
 	}
 
 	var dataStructure commands.Project
-	return ui.NewOutPutter(ctx.GlobalString("o"), res.Body, pc.out, projectTemplate, &dataStructure).Output()
+	return ui.NewPrinter(ctx.GlobalString("o"), res.Body, pc.out, projectTemplate, &dataStructure).Print()
 }
 
 // NewProjectCmd configures a new project command

--- a/commands/get/projects.go
+++ b/commands/get/projects.go
@@ -61,7 +61,7 @@ func (pc *projectsCmd) projectsAction(ctx *cli.Context) error {
 	}
 
 	var dataStructure []*commands.Project
-	return ui.NewOutPutter(ctx.GlobalString("o"), res.Body, pc.out, projectsTemplate, &dataStructure).Output()
+	return ui.NewPrinter(ctx.GlobalString("o"), res.Body, pc.out, projectsTemplate, &dataStructure).Print()
 }
 
 func handleProjectsResponseStatus(status int) error {

--- a/commands/get/templates.go
+++ b/commands/get/templates.go
@@ -81,7 +81,7 @@ func (tc *templatesCmd) templatesAction(ctx *cli.Context) error {
 	}
 	defer res.Body.Close()
 	var dataStructure []*commands.Template
-	return ui.NewOutPutter(ctx.GlobalString("o"), res.Body, tc.out, templatesTemplate, &dataStructure).Output()
+	return ui.NewPrinter(ctx.GlobalString("o"), res.Body, tc.out, templatesTemplate, &dataStructure).Print()
 }
 
 // handleTemplatesResponseStatus checks whether the API request returned an ok response

--- a/commands/get/templates.go
+++ b/commands/get/templates.go
@@ -49,7 +49,10 @@ type templatesCmd struct {
 	templateName string
 }
 
-var templatesTemplate = "{{range . }} | ID | {{.ID}} | Name | {{.Name}} | Category | {{.Category}} \n\n  {{end}}"
+var templatesTemplate = `
+| {{PadRight 14 " " "Id"}}| {{PadRight 14 " " "Name"}}| {{PadRight 14 " " "Category"}}|
+|-{{PadRight 14 "-" ""}}+-{{PadRight 14 "-" ""}}+-{{PadRight 14 "-" ""}}|{{range .}}
+| {{PadRight 14 " " .ID}}| {{PadRight 14 " " .Name}}| {{PadRight 14 " " .Category}}|{{end}}`
 
 // ListTemplates gets a list of templates of the supplied templateType (e.g. projects)
 func (tc *templatesCmd) templatesAction(ctx *cli.Context) error {
@@ -77,18 +80,8 @@ func (tc *templatesCmd) templatesAction(ctx *cli.Context) error {
 		return cli.NewExitError("could not create new request object "+err.Error(), 1)
 	}
 	defer res.Body.Close()
-
-	op := ui.NewOutPutter(res.Body, tc.out)
-	//handle Output
-	switch ctx.GlobalString("o") {
-	case "json":
-		return op.OutputJSON()
-	default:
-		var templatesModel []*commands.Template
-		return op.OutputTemplate(templatesTemplate, &templatesModel)
-	}
-
-	return nil
+	var dataStructure []*commands.Template
+	return ui.NewOutPutter(ctx.GlobalString("o"), res.Body, tc.out, templatesTemplate, &dataStructure).Output()
 }
 
 // handleTemplatesResponseStatus checks whether the API request returned an ok response

--- a/commands/get/templates_test.go
+++ b/commands/get/templates_test.go
@@ -5,10 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	"flag"
+
 	"github.com/feedhenry/rhm/storage"
 	"github.com/feedhenry/rhm/test/mock"
 	"github.com/urfave/cli"
-	"flag"
 )
 
 func TestTemplatesAction(t *testing.T) {

--- a/commands/get/templates_test.go
+++ b/commands/get/templates_test.go
@@ -7,9 +7,13 @@ import (
 
 	"github.com/feedhenry/rhm/storage"
 	"github.com/feedhenry/rhm/test/mock"
+	"github.com/urfave/cli"
+	"flag"
 )
 
 func TestTemplatesAction(t *testing.T) {
+	cxt := cli.NewContext(cli.NewApp(), flag.NewFlagSet("o", 0), nil)
+	cxt.GlobalSet("o", "json")
 	var (
 		mockStore = mock.UserDataStore(storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"))
 		in        bytes.Buffer
@@ -23,7 +27,7 @@ func TestTemplatesAction(t *testing.T) {
 		templateType: "projects",
 		getter:       mock.CreateRequest(t, 200, "testing.feedhenry.me/box/api/templates/projects", response),
 	}
-	if err := tCmd.templatesAction(nil); err != nil {
+	if err := tCmd.templatesAction(cxt); err != nil {
 		t.Fatal("failed to exectute templates cmd" + err.Error())
 	}
 	content := string(out.Bytes())
@@ -39,6 +43,8 @@ func TestTemplatesAction(t *testing.T) {
 }
 
 func TestTemplatesAction401Error(t *testing.T) {
+	cxt := cli.NewContext(cli.NewApp(), flag.NewFlagSet("o", 0), nil)
+	cxt.GlobalSet("o", "json")
 	var (
 		mockStore = mock.UserDataStore(storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"))
 		in        bytes.Buffer
@@ -52,12 +58,14 @@ func TestTemplatesAction401Error(t *testing.T) {
 		templateType: "projects",
 		getter:       mock.CreateRequest(t, 401, "testing.feedhenry.me/box/api/templates/projects", response),
 	}
-	if err := tCmd.templatesAction(nil); err == nil {
+	if err := tCmd.templatesAction(cxt); err == nil {
 		t.Fatal("expected an error executing command")
 	}
 }
 
 func TestTemplatesAction500Error(t *testing.T) {
+	cxt := cli.NewContext(cli.NewApp(), flag.NewFlagSet("o", 0), nil)
+	cxt.GlobalSet("o", "json")
 	var (
 		mockStore = mock.UserDataStore(storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"))
 		in        bytes.Buffer
@@ -71,7 +79,7 @@ func TestTemplatesAction500Error(t *testing.T) {
 		templateType: "projects",
 		getter:       mock.CreateRequest(t, 500, "testing.feedhenry.me/box/api/templates/projects", response),
 	}
-	if err := tCmd.templatesAction(nil); err == nil {
+	if err := tCmd.templatesAction(cxt); err == nil {
 		t.Fatal("expected an error executing command ")
 	}
 }

--- a/commands/login.go
+++ b/commands/login.go
@@ -99,10 +99,7 @@ func (lc *loginCmd) loginAction(ctx *cli.Context) error {
 	if err := lc.store.WriteUserData(userData); err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
-	outPuter := ui.NewOutPutter(res.Body, lc.out)
-	if "json" == ctx.GlobalString("o") {
-		return outPuter.OutputJSON()
-	}
+
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 			Name:        "o",
 			Destination: &outPutType,
 			Usage:       "-o=json",
+			Value: 	     "plain",
 		},
 	}
 	//create out data store for local file system

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 			Name:        "o",
 			Destination: &outPutType,
 			Usage:       "-o=json",
-			Value:       "plain",
+			Value:       "template",
 		},
 	}
 	//create out data store for local file system

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func main() {
 			Name:        "o",
 			Destination: &outPutType,
 			Usage:       "-o=json",
-			Value: 	     "plain",
+			Value:       "plain",
 		},
 	}
 	//create out data store for local file system

--- a/storage/userData.go
+++ b/storage/userData.go
@@ -47,7 +47,7 @@ func (ud *UserData) Validate() error {
 
 const (
 	//StorageDefaultLocation The default file for storing user data
-	StorageDefaultLocation = "/.rhm"
+	StorageDefaultLocation = "/.rhm.cfg"
 )
 
 func getHomeDir() (string, error) {

--- a/ui/helpers.go
+++ b/ui/helpers.go
@@ -17,6 +17,7 @@ func WaitForAnswer(question string, out io.Writer, in io.Reader) (string, error)
 	return scanner.Text(), nil
 }
 
+// PadRight takes a string and appends the pad character to the right of it, until it is as long as length
 func PadRight(length int, pad, str string) string {
 	for i := len(str); i < length; i += len(pad) {
 		str += pad
@@ -24,6 +25,7 @@ func PadRight(length int, pad, str string) string {
 	return str
 }
 
+// PadLeft takes a string and appends the pad character to the left of it, until it is as long as length
 func PadLeft(length int, pad, str string) string {
 	for i := len(str); i < length; i += len(pad) {
 		str = pad + str
@@ -31,6 +33,7 @@ func PadLeft(length int, pad, str string) string {
 	return str
 }
 
+// PadCentered takes a string and appends the pad character to the left and right of it, until it is as long as length
 func PadCentered(length int, pad, str string) string {
 	for i := len(str); i < length; i += len(pad) {
 		if i%2 == 0 {

--- a/ui/helpers.go
+++ b/ui/helpers.go
@@ -2,11 +2,7 @@ package ui
 
 import (
 	"bufio"
-	"bytes"
-	"encoding/json"
-	"html/template"
 	"io"
-	"io/ioutil"
 )
 
 //interface helpers help with the user interface
@@ -21,45 +17,27 @@ func WaitForAnswer(question string, out io.Writer, in io.Reader) (string, error)
 	return scanner.Text(), nil
 }
 
-// OutPutter handles output types
-type OutPutter struct {
-	in  io.ReadCloser
-	out io.Writer
+func PadRight(length int, pad, str string) string {
+	for i := len(str); i < length; i += len(pad) {
+		str += pad
+	}
+	return str
 }
 
-// NewOutPutter returns a configured OutPutter
-func NewOutPutter(in io.ReadCloser, out io.Writer) *OutPutter {
-	return &OutPutter{
-		in:  in,
-		out: out,
+func PadLeft(length int, pad, str string) string {
+	for i := len(str); i < length; i += len(pad) {
+		str = pad + str
 	}
+	return str
 }
 
-// OutputJSON outputs raw json from the reader
-func (o OutPutter) OutputJSON() error {
-	defer o.in.Close()
-	var dest bytes.Buffer
-	data, err := ioutil.ReadAll(o.in)
-	if err != nil {
-		return err
+func PadCentered(length int, pad, str string) string {
+	for i := len(str); i < length; i += len(pad) {
+		if i%2 == 0 {
+			str = pad + str
+		} else {
+			str += pad
+		}
 	}
-	if err := json.Indent(&dest, data, "", "\t"); err != nil {
-		return err
-	}
-	_, err = o.out.Write(dest.Bytes())
-	return err
-}
-
-// OutputTemplate takes a template string and outputs it based on the data in the reader. It exepects it to be JSON data
-func (o OutPutter) OutputTemplate(templateDef string, dataType interface{}) error {
-	dec := json.NewDecoder(o.in)
-	if err := dec.Decode(dataType); err != nil {
-		return err
-	}
-	t := template.New("cli template")
-	t, _ = t.Parse(templateDef)
-	if err := t.Execute(o.out, dataType); err != nil {
-		return err
-	}
-	return nil
+	return str
 }

--- a/ui/helpers_test.go
+++ b/ui/helpers_test.go
@@ -1,0 +1,43 @@
+package ui
+
+import "testing"
+
+func TestPadLeft(t *testing.T) {
+	res := PadLeft(8, " ", "test")
+	if res != "    test" {
+		t.Fatal("PadLeft got: '" + res + "', expected: '    test'")
+	}
+
+	res = PadLeft(3, " ", "test")
+	if res != "test" {
+		t.Fatal("PadLeft got: '" + res + "', expected: 'test'")
+	}
+}
+
+func TestPadRight(t *testing.T) {
+	res := PadRight(8, " ", "test")
+	if res != "test    " {
+		t.Fatal("PadRight got: '" + res + "', expected: 'test    '")
+	}
+
+	res = PadRight(3, " ", "test")
+	if res != "test" {
+		t.Fatal("PadRight got: '" + res + "', expected: 'test'")
+	}
+}
+
+func TestPadCentered(t *testing.T) {
+	res := PadCentered(8, " ", "test")
+	if res != "  test  " {
+		t.Fatal("PadCentered got: '" + res + "', expected: '  test  '")
+	}
+	res = PadCentered(9, " ", "test")
+	if res != "   test  " {
+		t.Fatal("PadCentered got: '" + res + "', expected: '   test  '")
+	}
+
+	res = PadCentered(3, " ", "test")
+	if res != "test" {
+		t.Fatal("PadCentered got: '" + res + "', expected: 'test'")
+	}
+}

--- a/ui/output.go
+++ b/ui/output.go
@@ -1,0 +1,87 @@
+package ui
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"io/ioutil"
+	"strings"
+)
+
+// OutPutter handles output types
+type OutPutter interface {
+	Output() error
+}
+
+type Throughput struct {
+	from io.ReadCloser
+	to   io.Writer
+}
+
+type JsonOutPutter struct {
+	Throughput
+	pretty bool
+}
+
+type PlainOutPutter struct {
+	Throughput
+	template      string
+	dataStructure interface{}
+}
+
+// NewOutPutter returns a configured OutPutter
+func NewOutPutter(format string, from io.ReadCloser, to io.Writer, template string, dataStructure interface{}) OutPutter {
+	switch strings.ToLower(format) {
+	case "json":
+		return &JsonOutPutter{Throughput: Throughput{from: from, to: to}, pretty: true}
+	default:
+		return &PlainOutPutter{Throughput: Throughput{from: from, to: to}, template: template, dataStructure: dataStructure}
+	}
+}
+
+// PrettyPrint enables or disables pretty json output
+func (j *JsonOutPutter) PrettyPrint(enabled bool) {
+	j.pretty = enabled
+}
+
+// Output outputs raw json from the reader
+func (j *JsonOutPutter) Output() error {
+	defer j.from.Close()
+	var dest bytes.Buffer
+	data, err := ioutil.ReadAll(j.from)
+	if err != nil {
+		return err
+	}
+	if j.pretty {
+		if err := json.Indent(&dest, data, "", "\t"); err != nil {
+			return err
+		}
+	}
+	_, err = j.to.Write(dest.Bytes())
+	return err
+}
+
+// OutputTemplate takes a template string and outputs it based on the data in the reader. It exepects it to be JSON data
+func (p PlainOutPutter) Output() error {
+	dec := json.NewDecoder(p.from)
+	if err := dec.Decode(p.dataStructure); err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	funcMap := map[string]interface{}{
+		"PadLeft":     PadLeft,
+		"PadRight":    PadRight,
+		"PadCentered": PadCentered,
+	}
+	template := template.New("cli output")
+	template.Funcs(funcMap)
+	template.Parse(p.template)
+	if err := template.Execute(p.to, p.dataStructure); err != nil {
+		fmt.Println(err)
+		return err
+	}
+	return nil
+}

--- a/ui/output.go
+++ b/ui/output.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-// OutPutter handles output types
+// Printer handles output types
 type Printer interface {
 	Print() error
 }
@@ -21,7 +21,7 @@ type JSONPrinter struct {
 	to   io.Writer
 }
 
-// templatePrinter reads from the from source, and sends to the destination. The output is determined by the template and the data is read into the
+// TemplatePrinter reads from the from source, and sends to the destination. The output is determined by the template and the data is read into the
 // dataStructure
 type TemplatePrinter struct {
 	from          io.ReadCloser
@@ -40,7 +40,7 @@ func NewPrinter(format string, from io.ReadCloser, to io.Writer, template string
 	}
 }
 
-// Output outputs raw json from the reader
+// Print outputs raw json from the reader
 func (j *JSONPrinter) Print() error {
 	defer j.from.Close()
 	var dest bytes.Buffer
@@ -55,7 +55,7 @@ func (j *JSONPrinter) Print() error {
 	return err
 }
 
-// Output takes a template string and outputs it based on the data in the reader. It exepects it to be JSON data
+// Print takes a template string and outputs it based on the data in the reader. It exepects it to be JSON data
 func (p TemplatePrinter) Print() error {
 	dec := json.NewDecoder(p.from)
 	if err := dec.Decode(p.dataStructure); err != nil {


### PR DESCRIPTION
Changes:
- Changed `~/.rhm` to `~/.rhm.cfg` as it conflicts with a file in use by operations team.
- Tidied up the plain text outputs.
- Added helper functions to make it easier to line up text in templates.
- Added tests for those helper functions
- Added an outputter factory
- Added a JSON outputter and a plain outputter
- Small updates to readme
- Fixed failing tests that weren't providing the context to the command actions