### PR TITLE
add project finder to project task

### DIFF
--- a/commands/get/project.go
+++ b/commands/get/project.go
@@ -26,7 +26,7 @@ type projectCmd struct {
 	out           io.Writer
 	store         storage.Storer
 	project       string
-	getter        commands.HttpGetter
+	getter        commands.HTTPGetter
 	projectFinder commands.ProjectFinder
 }
 
@@ -94,13 +94,13 @@ func NewProjectCmd(in io.Reader, out io.Writer, store storage.Storer) cli.Comman
 		out:           out,
 		store:         store,
 		getter:        http.DefaultClient.Do,
-		projectFinder: ProjectNameToGuid,
+		projectFinder: ProjectNameToGUID,
 	}
 	return pc.Project()
 }
 
-// ProjectNameToGuid will take a project title as an argument and find it in the core and return the guid for that name
-func ProjectNameToGuid(title string, userData *storage.UserData, getter commands.HttpGetter) (string, error) {
+// ProjectNameToGUID will take a project title as an argument and find it in the core and return the guid for that name
+func ProjectNameToGUID(title string, userData *storage.UserData, getter commands.HTTPGetter) (string, error) {
 	url := "%s/box/api/projects?apps=false"
 	fullURL := fmt.Sprintf(url, userData.Host)
 	newrequest, err := http.NewRequest("GET", fullURL, nil)

--- a/commands/get/project.go
+++ b/commands/get/project.go
@@ -1,6 +1,8 @@
 package get
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -20,11 +22,12 @@ var projectTemplate = `
 `
 
 type projectCmd struct {
-	in      io.Reader
-	out     io.Writer
-	store   storage.Storer
-	project string
-	getter  func(*http.Request) (*http.Response, error)
+	in            io.Reader
+	out           io.Writer
+	store         storage.Storer
+	project       string
+	getter        commands.HttpGetter
+	projectFinder commands.ProjectFinder
 }
 
 func (pc *projectCmd) Project() cli.Command {
@@ -52,7 +55,11 @@ func (pc *projectCmd) projectAction(ctx *cli.Context) error {
 		pc.project = uData.ActiveProject
 	}
 	if pc.project == "" {
-		return cli.NewExitError("expeced a project guid. Use --project", 1)
+		return cli.NewExitError("expeced a project guid or name. Use --project", 1)
+	}
+	guid, err := pc.projectFinder(pc.project, uData, pc.getter)
+	if err == nil {
+		pc.project = guid
 	}
 	url := fmt.Sprintf(urlTemplate, uData.Host, pc.project)
 	newrequest, err := http.NewRequest("GET", url, nil)
@@ -83,10 +90,46 @@ func (pc *projectCmd) projectAction(ctx *cli.Context) error {
 // NewProjectCmd configures a new project command
 func NewProjectCmd(in io.Reader, out io.Writer, store storage.Storer) cli.Command {
 	pc := &projectCmd{
-		in:     in,
-		out:    out,
-		store:  store,
-		getter: http.DefaultClient.Do,
+		in:            in,
+		out:           out,
+		store:         store,
+		getter:        http.DefaultClient.Do,
+		projectFinder: ProjectNameToGuid,
 	}
 	return pc.Project()
+}
+
+// ProjectNameToGuid will take a project title as an argument and find it in the core and return the guid for that name
+func ProjectNameToGuid(title string, userData *storage.UserData, getter commands.HttpGetter) (string, error) {
+	url := "%s/box/api/projects?apps=false"
+	fullURL := fmt.Sprintf(url, userData.Host)
+	newrequest, err := http.NewRequest("GET", fullURL, nil)
+	if err != nil {
+		return "", cli.NewExitError("could not create new request object "+err.Error(), 1)
+	}
+	// create a cookie
+	cookie := http.Cookie{Name: "feedhenry", Value: userData.Auth}
+	newrequest.AddCookie(&cookie)
+	//do request
+	res, err := getter(newrequest)
+	if err != nil {
+		return "", cli.NewExitError("could not create new request object "+err.Error(), 1)
+	}
+	//check if not authed)
+
+	//handle Output
+	var projects []*commands.Project
+
+	dec := json.NewDecoder(res.Body)
+	if err := dec.Decode(&projects); err != nil {
+		return "", err
+	}
+
+	for _, project := range projects {
+		if project.Title == title {
+			return project.GUID, nil
+		}
+	}
+
+	return "", errors.New("Project with title '" + title + "' not found.")
 }

--- a/commands/get/project_test.go
+++ b/commands/get/project_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-func mockProjectFinder(title string, userData *storage.UserData, getter commands.HttpGetter) (string, error) {
+func mockProjectFinder(title string, userData *storage.UserData, getter commands.HTTPGetter) (string, error) {
 	return "", errors.New("Project not found")
 }
 
@@ -85,7 +85,7 @@ func TestProjectNameToGuid(t *testing.T) {
 	mockResponse := `[{"guid": "347bkfnjoemm6cunjr2fbb6w", "title": "project_name"}]`
 	getter := mock.CreateRequest(t, 200, "testing.feedhenry.me/box/api/projects", mockResponse)
 
-	guid, err := ProjectNameToGuid("project_name", storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"), getter)
+	guid, err := ProjectNameToGUID("project_name", storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"), getter)
 	if err != nil {
 		t.Fatal("unexpected error: " + err.Error())
 	}

--- a/commands/get/project_test.go
+++ b/commands/get/project_test.go
@@ -93,4 +93,15 @@ func TestProjectNameToGuid(t *testing.T) {
 	if guid != "347bkfnjoemm6cunjr2fbb6w" {
 		t.Fatal("expected guid: 347bkfnjoemm6cunjr2fbb6w got: " + guid)
 	}
+
+	getter = mock.CreateRequest(t, 200, "testing.feedhenry.me/box/api/projects", mockResponse)
+
+	guid, err = ProjectNameToGUID("bad_project_name", storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"), getter)
+	if err == nil {
+		t.Fatal("expected error got nil")
+	}
+
+	if guid != "" {
+		t.Fatal("expected guid to be empty, got: " + guid)
+	}
 }

--- a/commands/get/project_test.go
+++ b/commands/get/project_test.go
@@ -6,10 +6,17 @@ import (
 	"strings"
 	"testing"
 
+	"errors"
+
+	"github.com/feedhenry/rhm/commands"
 	"github.com/feedhenry/rhm/storage"
 	"github.com/feedhenry/rhm/test/mock"
 	"github.com/urfave/cli"
 )
+
+func mockProjectFinder(title string, userData *storage.UserData, getter commands.HttpGetter) (string, error) {
+	return "", errors.New("Project not found")
+}
 
 func TestProjectAction(t *testing.T) {
 	var (
@@ -23,11 +30,12 @@ func TestProjectAction(t *testing.T) {
 		mockResponse := `{"title": "cordova-test", "guid": "scqswfv56m7fktyijkfw6tkd"}`
 		getter := mock.CreateRequest(t, 200, "testing.feedhenry.me/box/api/projects/scqswfv56m7fktyijkfw6tkd", mockResponse)
 		pCommand := projectCmd{
-			in:      &in,
-			out:     &out,
-			store:   mockStore,
-			getter:  getter,
-			project: "scqswfv56m7fktyijkfw6tkd",
+			in:            &in,
+			out:           &out,
+			store:         mockStore,
+			getter:        getter,
+			project:       "scqswfv56m7fktyijkfw6tkd",
+			projectFinder: mockProjectFinder,
 		}
 
 		if err := pCommand.projectAction(ctx); err != nil {
@@ -43,11 +51,12 @@ func TestProjectAction(t *testing.T) {
 		mockResponse := `{"status": "error", "message": "unexpected error"}`
 		getter := mock.CreateRequest(t, 500, "testing.feedhenry.me/box/api/projects/scqswfv56m7fktyijkfw6tkd", mockResponse)
 		pCommand := projectCmd{
-			in:      &in,
-			out:     &out,
-			store:   mockStore,
-			getter:  getter,
-			project: "scqswfv56m7fktyijkfw6tkd",
+			in:            &in,
+			out:           &out,
+			store:         mockStore,
+			getter:        getter,
+			project:       "scqswfv56m7fktyijkfw6tkd",
+			projectFinder: mockProjectFinder,
 		}
 		if err := pCommand.projectAction(ctx); err == nil {
 			t.Fatal("expected an error ", err.Error())
@@ -58,15 +67,30 @@ func TestProjectAction(t *testing.T) {
 		mockResponse := `{"status": "error", "message": "unexpected error"}`
 		getter := mock.CreateRequest(t, 401, "testing.feedhenry.me/box/api/projects/scqswfv56m7fktyijkfw6tkd", mockResponse)
 		pCommand := projectCmd{
-			in:      &in,
-			out:     &out,
-			store:   mockStore,
-			getter:  getter,
-			project: "scqswfv56m7fktyijkfw6tkd",
+			in:            &in,
+			out:           &out,
+			store:         mockStore,
+			getter:        getter,
+			project:       "scqswfv56m7fktyijkfw6tkd",
+			projectFinder: mockProjectFinder,
 		}
 		if err := pCommand.projectAction(ctx); err == nil {
 			t.Fatal("expected an error ", err.Error())
 		}
 	})
 
+}
+
+func TestProjectNameToGuid(t *testing.T) {
+	mockResponse := `[{"guid": "347bkfnjoemm6cunjr2fbb6w", "title": "project_name"}]`
+	getter := mock.CreateRequest(t, 200, "testing.feedhenry.me/box/api/projects", mockResponse)
+
+	guid, err := ProjectNameToGuid("project_name", storage.NewUserData("test", "test@test.com", "testing.feedhenry.me", "testing"), getter)
+	if err != nil {
+		t.Fatal("unexpected error: " + err.Error())
+	}
+
+	if guid != "347bkfnjoemm6cunjr2fbb6w" {
+		t.Fatal("expected guid: 347bkfnjoemm6cunjr2fbb6w got: " + guid)
+	}
 }

--- a/commands/types.go
+++ b/commands/types.go
@@ -30,8 +30,11 @@ type Project struct {
 	Apps           []*App      `json:"apps,omitempty"`
 }
 
-type HttpGetter func(*http.Request) (*http.Response, error)
-type ProjectFinder func(string, *storage.UserData, HttpGetter) (string, error)
+// HTTPGetter accepts a http request and returns the http response
+type HTTPGetter func(*http.Request) (*http.Response, error)
+
+// ProjectFinder takes a project name, user details and a httpGetter and returns the project guid
+type ProjectFinder func(string, *storage.UserData, HTTPGetter) (string, error)
 
 // App defines an app request object
 type App struct {

--- a/commands/types.go
+++ b/commands/types.go
@@ -1,5 +1,11 @@
 package commands
 
+import (
+	"net/http"
+
+	"github.com/feedhenry/rhm/storage"
+)
+
 // define all the types used in a common file
 
 // Project defines the project response object
@@ -23,6 +29,9 @@ type Project struct {
 	Type           string      `json:"type"`
 	Apps           []*App      `json:"apps,omitempty"`
 }
+
+type HttpGetter func(*http.Request) (*http.Response, error)
+type ProjectFinder func(string, *storage.UserData, HttpGetter) (string, error)
 
 // App defines an app request object
 type App struct {


### PR DESCRIPTION
This change makes it possible to do:
```
rhm get project --project=project-title
```
As well as:
```
rhm get project --project=scqswfv56m7fktyijkfw6tkd
```